### PR TITLE
`mask` CSS properties require `-webkit-` prefixes

### DIFF
--- a/src/design/index.css
+++ b/src/design/index.css
@@ -103,16 +103,22 @@ body {
 .icon-eye {
   mask: url(/assets/icon-eye.svg) no-repeat center;
   mask-size: contain;
+  -webkit-mask: url(/assets/icon-eye.svg) no-repeat center;
+  -webkit-mask-size: contain;
 }
 
 .icon-settings {
   mask: url(/assets/icon-settings.svg) no-repeat center;
   mask-size: contain;
+  -webkit-mask: url(/assets/icon-settings.svg) no-repeat center;
+  -webkit-mask-size: contain;
 }
 
 .icon-trash {
   mask: url(/assets/icon-trash.svg) no-repeat center;
   mask-size: contain;
+  -webkit-mask: url(/assets/icon-trash.svg) no-repeat center;
+  -webkit-mask-size: contain;
   margin-top: 0.05em;
   height: 0.85em;
   width: 0.85em;


### PR DESCRIPTION
I noticed that the svg icons weren't rendering in Chrome/Beaker:

<img width="491" alt="screen shot 2018-06-03 at 12 21 37 pm" src="https://user-images.githubusercontent.com/59404/40888716-2295ef7e-6729-11e8-806f-200082e99921.png">

MDN [sez](https://developer.mozilla.org/en-US/docs/Web/CSS/mask) they still require a `-webkit-` prefix so I've just made that small fix.