### PR TITLE
custom css support

### DIFF
--- a/src/components/css.js
+++ b/src/components/css.js
@@ -157,6 +157,8 @@ function Css (state, emit) {
       body .tags-input input {
         color: ${colorFg};
       }
+
+      ${state.options.values.css}
     </style>
   `
 }

--- a/src/containers/panel-options.js
+++ b/src/containers/panel-options.js
@@ -53,7 +53,12 @@ function view (state, emit) {
       </div>
       <div class="c12 x">
         <div class="xx p1px curp tac">
-          <a href="/data" class="line bg-white db bribl tc-black">
+          <a href="/css" class="line bg-white db bribl tc-black">
+            CSS
+          </a>
+        </div>
+        <div class="xx p1px curp tac">
+          <a href="/data" class="line bg-white db tc-black">
             Data
           </a>
         </div>

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ app.use(require('enoki/choo')('content', {
 app.route('/', wrapper(require('./templates/home')))
 app.route('/all', wrapper(require('./templates/home')))
 app.route('/suggestions', wrapper(require('./templates/suggestions')))
+app.route('/css', wrapper(require('./templates/css')))
 
 // content
 app.route('/about', wrapper(require('./templates/about')))

--- a/src/templates/css.js
+++ b/src/templates/css.js
@@ -1,0 +1,90 @@
+var html = require('choo/html')
+var ov = require('object-values')
+
+var css = require('../components/css')
+
+var navigationOpts = {
+  customcss: {
+    key: 'css',
+    text: 'Custom CSS'
+  }
+}
+
+var getCommand = command => command || 'css'
+
+module.exports = view
+
+function handleSaveClick (event, emit) {
+  var input = event.target.parentNode.querySelector('textarea')
+  var value = input.value || ''
+
+  try {
+    // var result = JSON.parse(value)
+    emit('options:values', {
+      key: 'css',
+      value: value
+    })
+    alert('updated!')
+  } catch (err) {
+    alert('Please enter valid CSS')
+    console.warn(err)
+  }
+}
+
+function elNavigation (state, emit) {
+  var command = getCommand(state.params.command)
+  var opts = ov(navigationOpts)
+
+  var elsOpts = opts.map((opt, i) => html`
+    <a
+      href="/${opt.key}"
+      class="xx tc-black px1 br2-lighter"
+    >
+      <span class="${opt.key === command ? 'op100' : 'op33 oph100'}">
+        ${opt.text}
+      </span>
+    </a>
+  `)
+
+  return html`<div
+    class="x fs1 psf t0 l0 r0 z2 bb2-lighter"
+    style="line-height: 4.5rem"
+  >
+    ${elsOpts}
+    <a
+      href="/" 
+      class="tac tc-black fs1-4"
+      style="width: 4.5rem; height: 4.5rem"
+    >×</a>
+  </div>`
+}
+
+function elCustomCss (state, emit) {
+  var customcss = state.options.values.css
+  return html`<div class="data">
+    <textarea
+      class="mono bg-white tc-black p1 fs1 lh1-5"
+      placeholder="Must be valid CSS"
+      style="height: calc(100vh - 4.5rem)"
+    >${customcss}</textarea>
+    <div
+      class="fs1 psf b0 r0 z2 bg-white tc-black py1 px2 curp"
+      onclick=${event => handleSaveClick(event, emit)}
+    >Submit</div>
+  </div>`
+}
+
+function view (state, emit) {
+  var command = getCommand(state.params.command)
+  var elContent = getContent()
+
+  return html`<div class="sans">
+    ${elNavigation(state, emit)}
+    ${elContent(state, emit)}
+    ${css(state, emit)}
+  </div>`
+
+  function getContent () {
+    return elCustomCss
+  }
+}


### PR DESCRIPTION
yo! First attempt at custom css support, not expecting a direct merge, we can still iterate on the interface. atm I just created a separate view `/css` which functions similar to `/data`. custom css is saved into `options` under key `css`. a better interface might be to just make a little accordion style textarea for editing custom css directly within the options panel (kinda like when you click font).

i added this to give more granular control over css w/o needing full fork. for example, editing line-height.

some images:

![options](http://jongacnik.com/assets/hardly/01.png)
![editing](http://jongacnik.com/assets/hardly/02.png)
![result](http://jongacnik.com/assets/hardly/03.png)