### PR TITLE
`normalizeUrl` is too strict

### DIFF
--- a/src/plugins/entries.js
+++ b/src/plugins/entries.js
@@ -226,6 +226,9 @@ function formatEntry (data) {
   for (var key in result) {
     switch (key) {
       case 'url':
+        // TODO this strips `www` from URLs which breaks things that don't have proper redirects setup
+        // TODO this doesn't allow query params
+        // https://mobile.twitter.com/search?q=filter%3Afollows%20-filter%3Aretweets%20-filter%3Areplies%20-filter%3Alikes&src=typed_query&f=live
         result.url = result.url ? normalizeUrl(result.url) : ''
         break
     }


### PR DESCRIPTION
I've found that the `normalize-url` package used is too strict. for example, it removes `www` from urls, but some sites don't redirect correctly so this breaks those links:

https://www.robinsloan.com -> works
https://robinsloan.com -> does not work

it also strips query params, which can sometimes be useful. I'm less concerned about this issue though.

I'm happy to look into & make a PR for a fix, but I wanted to see if this would be an acceptable feature before doing the work.